### PR TITLE
Fix for issue #6 IE9 fallback support for linear gradients

### DIFF
--- a/docs/themes/aloe/jquery.mobile-1.3.1.css
+++ b/docs/themes/aloe/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#648100 /*{b-bar-border}*/;
-	background: 			#abcd14 /*{b-bar-background-color}*/;
+	background: 			#94b913 /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #abcd14 /*{b-bar-background-start}*/), to( #94b913 /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#94b913 /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #94b913 /*{c-bdown-background-start}*/), to( #94b913 /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/aloe/jquery.mobile-1.3.1.css
+++ b/docs/themes/aloe/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#648100 /*{a-bar-border}*/;
-	background: 			#abcd14 /*{a-bar-background-color}*/;
+	background: 			#94b913 /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #abcd14 /*{a-bar-background-start}*/), to( #94b913 /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/aloe/jquery.mobile-1.3.1.css
+++ b/docs/themes/aloe/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#abcd14 /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #abcd14 /*{c-bhover-background-start}*/), to( #abcd14 /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/aloe/jquery.mobile-1.3.1.css
+++ b/docs/themes/aloe/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#94b913 /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#abcd14 /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #abcd14 /*{a-bup-background-start}*/), to( #abcd14 /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#94b913 /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#abcd14 /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #abcd14 /*{a-bhover-background-start}*/), to( #abcd14 /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#94b913 /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #94b913 /*{a-bdown-background-start}*/), to( #94b913 /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/candy/jquery.mobile-1.3.1.css
+++ b/docs/themes/candy/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#ff6b5f /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ff6b5f /*{c-bhover-background-start}*/), to( #ff6b5f /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/candy/jquery.mobile-1.3.1.css
+++ b/docs/themes/candy/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#a9281e /*{a-bar-border}*/;
-	background: 			#ff6b5f /*{a-bar-background-color}*/;
+	background: 			#f75548 /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ff6b5f /*{a-bar-background-start}*/), to( #f75548 /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/candy/jquery.mobile-1.3.1.css
+++ b/docs/themes/candy/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#f75548 /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#ff6b5f /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ff6b5f /*{a-bup-background-start}*/), to( #ff6b5f /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#f75548 /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#ff6b5f /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ff6b5f /*{a-bhover-background-start}*/), to( #ff6b5f /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#f75548 /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #f75548 /*{a-bdown-background-start}*/), to( #f75548 /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/candy/jquery.mobile-1.3.1.css
+++ b/docs/themes/candy/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#a9281e /*{b-bar-border}*/;
-	background: 			#ff6b5f /*{b-bar-background-color}*/;
+	background: 			#f75548 /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ff6b5f /*{b-bar-background-start}*/), to( #f75548 /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#f75548 /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #f75548 /*{c-bdown-background-start}*/), to( #f75548 /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/melon/jquery.mobile-1.3.1.css
+++ b/docs/themes/melon/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#d0a100 /*{a-bar-border}*/;
-	background: 			#ffd55f /*{a-bar-background-color}*/;
+	background: 			#f8c84a /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ffd55f /*{a-bar-background-start}*/), to( #f8c84a /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/melon/jquery.mobile-1.3.1.css
+++ b/docs/themes/melon/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#f8c84a /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#ffd55f /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ffd55f /*{a-bup-background-start}*/), to( #ffd55f /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#f8c84a /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#ffd55f /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ffd55f /*{a-bhover-background-start}*/), to( #ffd55f /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#f8c84a /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #f8c84a /*{a-bdown-background-start}*/), to( #f8c84a /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/melon/jquery.mobile-1.3.1.css
+++ b/docs/themes/melon/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#d0a100 /*{b-bar-border}*/;
-	background: 			#ffd55f /*{b-bar-background-color}*/;
+	background: 			#f8c84a /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ffd55f /*{b-bar-background-start}*/), to( #f8c84a /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#f8c84a /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #f8c84a /*{c-bdown-background-start}*/), to( #f8c84a /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/melon/jquery.mobile-1.3.1.css
+++ b/docs/themes/melon/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#ffd55f /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ffd55f /*{c-bhover-background-start}*/), to( #ffd55f /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/mint/jquery.mobile-1.3.1.css
+++ b/docs/themes/mint/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#259375 /*{a-bar-border}*/;
-	background: 			#9bdecc /*{a-bar-background-color}*/;
+	background: 			#72c6ae /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9bdecc /*{a-bar-background-start}*/), to( #72c6ae /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/mint/jquery.mobile-1.3.1.css
+++ b/docs/themes/mint/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#259375 /*{b-bar-border}*/;
-	background: 			#9bdecc /*{b-bar-background-color}*/;
+	background: 			#72c6ae /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9bdecc /*{b-bar-background-start}*/), to( #72c6ae /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#72c6ae /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #72c6ae /*{c-bdown-background-start}*/), to( #72c6ae /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/mint/jquery.mobile-1.3.1.css
+++ b/docs/themes/mint/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#9bdecc /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9bdecc /*{c-bhover-background-start}*/), to( #9bdecc /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/mint/jquery.mobile-1.3.1.css
+++ b/docs/themes/mint/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#72c6ae /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#9bdecc /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9bdecc /*{a-bup-background-start}*/), to( #9bdecc /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#72c6ae /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#9bdecc /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9bdecc /*{a-bhover-background-start}*/), to( #9bdecc /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#72c6ae /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #72c6ae /*{a-bdown-background-start}*/), to( #72c6ae /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/royal/jquery.mobile-1.3.1.css
+++ b/docs/themes/royal/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#c22f1b /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #c22f1b /*{c-bhover-background-start}*/), to( #c22f1b /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/royal/jquery.mobile-1.3.1.css
+++ b/docs/themes/royal/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#9e2417 /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#c22f1b /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #c22f1b /*{a-bup-background-start}*/), to( #c22f1b /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#9e2417 /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#c22f1b /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #c22f1b /*{a-bhover-background-start}*/), to( #c22f1b /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#9e2417 /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9e2417 /*{a-bdown-background-start}*/), to( #9e2417 /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/royal/jquery.mobile-1.3.1.css
+++ b/docs/themes/royal/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#490100 /*{a-bar-border}*/;
-	background: 			#c22f1b /*{a-bar-background-color}*/;
+	background: 			#9e2417 /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #c22f1b /*{a-bar-background-start}*/), to( #9e2417 /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/royal/jquery.mobile-1.3.1.css
+++ b/docs/themes/royal/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#490100 /*{b-bar-border}*/;
-	background: 			#c22f1b /*{b-bar-background-color}*/;
+	background: 			#9e2417 /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #c22f1b /*{b-bar-background-start}*/), to( #9e2417 /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#9e2417 /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9e2417 /*{c-bdown-background-start}*/), to( #9e2417 /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/sand/jquery.mobile-1.3.1.css
+++ b/docs/themes/sand/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#8b6945 /*{a-bar-border}*/;
-	background: 			#cbb294 /*{a-bar-background-color}*/;
+	background: 			#b29573 /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #cbb294 /*{a-bar-background-start}*/), to( #b29573 /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/sand/jquery.mobile-1.3.1.css
+++ b/docs/themes/sand/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#cbb294 /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #cbb294 /*{c-bhover-background-start}*/), to( #cbb294 /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/sand/jquery.mobile-1.3.1.css
+++ b/docs/themes/sand/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#8b6945 /*{b-bar-border}*/;
-	background: 			#cbb294 /*{b-bar-background-color}*/;
+	background: 			#b29573 /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #cbb294 /*{b-bar-background-start}*/), to( #b29573 /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#b29573 /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #b29573 /*{c-bdown-background-start}*/), to( #b29573 /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/sand/jquery.mobile-1.3.1.css
+++ b/docs/themes/sand/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#b29573 /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#cbb294 /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #cbb294 /*{a-bup-background-start}*/), to( #cbb294 /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#b29573 /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#cbb294 /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #cbb294 /*{a-bhover-background-start}*/), to( #cbb294 /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#b29573 /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #b29573 /*{a-bdown-background-start}*/), to( #b29573 /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/slate/jquery.mobile-1.3.1.css
+++ b/docs/themes/slate/jquery.mobile-1.3.1.css
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#333333 /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#727272 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #333333 /*{c-bdown-background-start}*/), to( #333333 /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/slate/jquery.mobile-1.3.1.css
+++ b/docs/themes/slate/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#000000 /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#333333 /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #333333 /*{a-bup-background-start}*/), to( #333333 /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#222222 /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#222222 /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #222222 /*{a-bhover-background-start}*/), to( #222222 /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#222222 /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #222222 /*{a-bdown-background-start}*/), to( #222222 /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#333333 /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #333333 /*{c-bhover-background-start}*/), to( #333333 /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/water/jquery.mobile-1.3.1.css
+++ b/docs/themes/water/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#005994 /*{b-bar-border}*/;
-	background: 			#0093EA /*{b-bar-background-color}*/;
+	background: 			#007dcd /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #0093EA /*{b-bar-background-start}*/), to( #007dcd /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#007dcd /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #007dcd /*{c-bdown-background-start}*/), to( #007dcd /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/water/jquery.mobile-1.3.1.css
+++ b/docs/themes/water/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#0093EA /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #0093EA /*{c-bhover-background-start}*/), to( #0093EA /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/water/jquery.mobile-1.3.1.css
+++ b/docs/themes/water/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#005994 /*{a-bar-border}*/;
-	background: 			#0093EA /*{a-bar-background-color}*/;
+	background: 			#007dcd /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #0093EA /*{a-bar-background-start}*/), to( #007dcd /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/docs/themes/water/jquery.mobile-1.3.1.css
+++ b/docs/themes/water/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#007dcd /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#0093EA /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #0093EA /*{a-bup-background-start}*/), to( #0093EA /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#007dcd /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#0093EA /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #0093EA /*{a-bhover-background-start}*/), to( #0093EA /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#007dcd /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #007dcd /*{a-bdown-background-start}*/), to( #007dcd /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/aloe/jquery.mobile-1.3.1.css
+++ b/generated/aloe/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#648100 /*{b-bar-border}*/;
-	background: 			#abcd14 /*{b-bar-background-color}*/;
+	background: 			#94b913 /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #abcd14 /*{b-bar-background-start}*/), to( #94b913 /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#94b913 /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #94b913 /*{c-bdown-background-start}*/), to( #94b913 /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/aloe/jquery.mobile-1.3.1.css
+++ b/generated/aloe/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#648100 /*{a-bar-border}*/;
-	background: 			#abcd14 /*{a-bar-background-color}*/;
+	background: 			#94b913 /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #abcd14 /*{a-bar-background-start}*/), to( #94b913 /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/aloe/jquery.mobile-1.3.1.css
+++ b/generated/aloe/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#abcd14 /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #abcd14 /*{c-bhover-background-start}*/), to( #abcd14 /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/aloe/jquery.mobile-1.3.1.css
+++ b/generated/aloe/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#94b913 /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#abcd14 /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #abcd14 /*{a-bup-background-start}*/), to( #abcd14 /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#94b913 /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#abcd14 /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #abcd14 /*{a-bhover-background-start}*/), to( #abcd14 /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#94b913 /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #94b913 /*{a-bdown-background-start}*/), to( #94b913 /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/candy/jquery.mobile-1.3.1.css
+++ b/generated/candy/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#ff6b5f /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ff6b5f /*{c-bhover-background-start}*/), to( #ff6b5f /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/candy/jquery.mobile-1.3.1.css
+++ b/generated/candy/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#a9281e /*{a-bar-border}*/;
-	background: 			#ff6b5f /*{a-bar-background-color}*/;
+	background: 			#f75548 /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ff6b5f /*{a-bar-background-start}*/), to( #f75548 /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/candy/jquery.mobile-1.3.1.css
+++ b/generated/candy/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#f75548 /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#ff6b5f /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ff6b5f /*{a-bup-background-start}*/), to( #ff6b5f /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#f75548 /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#ff6b5f /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ff6b5f /*{a-bhover-background-start}*/), to( #ff6b5f /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#f75548 /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #f75548 /*{a-bdown-background-start}*/), to( #f75548 /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/candy/jquery.mobile-1.3.1.css
+++ b/generated/candy/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#a9281e /*{b-bar-border}*/;
-	background: 			#ff6b5f /*{b-bar-background-color}*/;
+	background: 			#f75548 /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ff6b5f /*{b-bar-background-start}*/), to( #f75548 /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#f75548 /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #f75548 /*{c-bdown-background-start}*/), to( #f75548 /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/melon/jquery.mobile-1.3.1.css
+++ b/generated/melon/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#d0a100 /*{a-bar-border}*/;
-	background: 			#ffd55f /*{a-bar-background-color}*/;
+	background: 			#f8c84a /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ffd55f /*{a-bar-background-start}*/), to( #f8c84a /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/melon/jquery.mobile-1.3.1.css
+++ b/generated/melon/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#f8c84a /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#ffd55f /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ffd55f /*{a-bup-background-start}*/), to( #ffd55f /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#f8c84a /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#ffd55f /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ffd55f /*{a-bhover-background-start}*/), to( #ffd55f /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#f8c84a /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #f8c84a /*{a-bdown-background-start}*/), to( #f8c84a /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/melon/jquery.mobile-1.3.1.css
+++ b/generated/melon/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#d0a100 /*{b-bar-border}*/;
-	background: 			#ffd55f /*{b-bar-background-color}*/;
+	background: 			#f8c84a /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ffd55f /*{b-bar-background-start}*/), to( #f8c84a /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#f8c84a /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #f8c84a /*{c-bdown-background-start}*/), to( #f8c84a /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/melon/jquery.mobile-1.3.1.css
+++ b/generated/melon/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#ffd55f /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #ffd55f /*{c-bhover-background-start}*/), to( #ffd55f /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/mint/jquery.mobile-1.3.1.css
+++ b/generated/mint/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#259375 /*{a-bar-border}*/;
-	background: 			#9bdecc /*{a-bar-background-color}*/;
+	background: 			#72c6ae /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9bdecc /*{a-bar-background-start}*/), to( #72c6ae /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/mint/jquery.mobile-1.3.1.css
+++ b/generated/mint/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#259375 /*{b-bar-border}*/;
-	background: 			#9bdecc /*{b-bar-background-color}*/;
+	background: 			#72c6ae /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9bdecc /*{b-bar-background-start}*/), to( #72c6ae /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#72c6ae /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #72c6ae /*{c-bdown-background-start}*/), to( #72c6ae /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/mint/jquery.mobile-1.3.1.css
+++ b/generated/mint/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#9bdecc /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9bdecc /*{c-bhover-background-start}*/), to( #9bdecc /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/mint/jquery.mobile-1.3.1.css
+++ b/generated/mint/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#72c6ae /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#9bdecc /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9bdecc /*{a-bup-background-start}*/), to( #9bdecc /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#72c6ae /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#9bdecc /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9bdecc /*{a-bhover-background-start}*/), to( #9bdecc /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#72c6ae /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #72c6ae /*{a-bdown-background-start}*/), to( #72c6ae /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/royal/jquery.mobile-1.3.1.css
+++ b/generated/royal/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#c22f1b /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #c22f1b /*{c-bhover-background-start}*/), to( #c22f1b /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/royal/jquery.mobile-1.3.1.css
+++ b/generated/royal/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#9e2417 /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#c22f1b /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #c22f1b /*{a-bup-background-start}*/), to( #c22f1b /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#9e2417 /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#c22f1b /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #c22f1b /*{a-bhover-background-start}*/), to( #c22f1b /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#9e2417 /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9e2417 /*{a-bdown-background-start}*/), to( #9e2417 /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/royal/jquery.mobile-1.3.1.css
+++ b/generated/royal/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#490100 /*{a-bar-border}*/;
-	background: 			#c22f1b /*{a-bar-background-color}*/;
+	background: 			#9e2417 /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #c22f1b /*{a-bar-background-start}*/), to( #9e2417 /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/royal/jquery.mobile-1.3.1.css
+++ b/generated/royal/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#490100 /*{b-bar-border}*/;
-	background: 			#c22f1b /*{b-bar-background-color}*/;
+	background: 			#9e2417 /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #c22f1b /*{b-bar-background-start}*/), to( #9e2417 /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#9e2417 /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #9e2417 /*{c-bdown-background-start}*/), to( #9e2417 /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/sand/jquery.mobile-1.3.1.css
+++ b/generated/sand/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#8b6945 /*{a-bar-border}*/;
-	background: 			#cbb294 /*{a-bar-background-color}*/;
+	background: 			#b29573 /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #cbb294 /*{a-bar-background-start}*/), to( #b29573 /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/sand/jquery.mobile-1.3.1.css
+++ b/generated/sand/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#cbb294 /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #cbb294 /*{c-bhover-background-start}*/), to( #cbb294 /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/sand/jquery.mobile-1.3.1.css
+++ b/generated/sand/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#8b6945 /*{b-bar-border}*/;
-	background: 			#cbb294 /*{b-bar-background-color}*/;
+	background: 			#b29573 /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #cbb294 /*{b-bar-background-start}*/), to( #b29573 /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#b29573 /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #b29573 /*{c-bdown-background-start}*/), to( #b29573 /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/sand/jquery.mobile-1.3.1.css
+++ b/generated/sand/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#b29573 /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#cbb294 /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #cbb294 /*{a-bup-background-start}*/), to( #cbb294 /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#b29573 /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#cbb294 /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #cbb294 /*{a-bhover-background-start}*/), to( #cbb294 /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#b29573 /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #b29573 /*{a-bdown-background-start}*/), to( #b29573 /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/slate/jquery.mobile-1.3.1.css
+++ b/generated/slate/jquery.mobile-1.3.1.css
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#333333 /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#727272 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #333333 /*{c-bdown-background-start}*/), to( #333333 /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/slate/jquery.mobile-1.3.1.css
+++ b/generated/slate/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#000000 /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#333333 /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #333333 /*{a-bup-background-start}*/), to( #333333 /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#222222 /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#222222 /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #222222 /*{a-bhover-background-start}*/), to( #222222 /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#222222 /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #222222 /*{a-bdown-background-start}*/), to( #222222 /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#333333 /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #333333 /*{c-bhover-background-start}*/), to( #333333 /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/water/jquery.mobile-1.3.1.css
+++ b/generated/water/jquery.mobile-1.3.1.css
@@ -148,7 +148,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-b {
 	border: 1px solid 		#005994 /*{b-bar-border}*/;
-	background: 			#0093EA /*{b-bar-background-color}*/;
+	background: 			#007dcd /*{b-bar-background-color}*/;
 	color: 					#fff /*{b-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #0093EA /*{b-bar-background-start}*/), to( #007dcd /*{b-bar-background-end}*/)); /* Saf4+, Chrome */
@@ -388,7 +388,7 @@
 }
 .ui-btn-down-c {
 	border: 1px solid 		#bbb /*{c-bdown-border}*/;
-	background: 			#d6d6d6 /*{c-bdown-background-color}*/;
+	background: 			#007dcd /*{c-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#222 /*{c-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #007dcd /*{c-bdown-background-start}*/), to( #007dcd /*{c-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/water/jquery.mobile-1.3.1.css
+++ b/generated/water/jquery.mobile-1.3.1.css
@@ -371,7 +371,7 @@
 }
 .ui-btn-hover-c {
 	border: 1px solid 		#bbb /*{c-bhover-border}*/;
-	background: 			#dfdfdf /*{c-bhover-background-color}*/;
+	background: 			#0093EA /*{c-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{c-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #0093EA /*{c-bhover-background-start}*/), to( #0093EA /*{c-bhover-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/water/jquery.mobile-1.3.1.css
+++ b/generated/water/jquery.mobile-1.3.1.css
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------------------------------------*/
 .ui-bar-a {
 	border: 1px solid 		#005994 /*{a-bar-border}*/;
-	background: 			#0093EA /*{a-bar-background-color}*/;
+	background: 			#007dcd /*{a-bar-background-color}*/;
 	color: 					#fff /*{a-bar-color}*/;
 	font-weight: bold;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #0093EA /*{a-bar-background-start}*/), to( #007dcd /*{a-bar-background-end}*/)); /* Saf4+, Chrome */

--- a/generated/water/jquery.mobile-1.3.1.css
+++ b/generated/water/jquery.mobile-1.3.1.css
@@ -90,7 +90,7 @@
 }
 .ui-btn-up-a {
 	border: 1px solid 		#007dcd /*{a-bup-border}*/;
-	background: 			#333 /*{a-bup-background-color}*/;
+	background: 			#0093EA /*{a-bup-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bup-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #0093EA /*{a-bup-background-start}*/), to( #0093EA /*{a-bup-background-end}*/)); /* Saf4+, Chrome */
@@ -106,7 +106,7 @@
 }
 .ui-btn-hover-a {
 	border: 1px solid 		#007dcd /*{a-bhover-border}*/;
-	background: 			#444 /*{a-bhover-background-color}*/;
+	background: 			#0093EA /*{a-bhover-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bhover-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #0093EA /*{a-bhover-background-start}*/), to( #0093EA /*{a-bhover-background-end}*/)); /* Saf4+, Chrome */
@@ -123,7 +123,7 @@
 }
 .ui-btn-down-a {
 	border: 1px solid 		#000 /*{a-bdown-border}*/;
-	background: 			#222 /*{a-bdown-background-color}*/;
+	background: 			#007dcd /*{a-bdown-background-color}*/;
 	font-weight: bold;
 	color: 					#fff /*{a-bdown-color}*/;
 	background-image: -webkit-gradient(linear, left top, left bottom, from( #007dcd /*{a-bdown-background-start}*/), to( #007dcd /*{a-bdown-background-end}*/)); /* Saf4+, Chrome */

--- a/themes/base.yaml
+++ b/themes/base.yaml
@@ -68,6 +68,7 @@
 
 'c-bup-background-start': '#fff'
 'c-bup-background-end': '#fff'
+'c-bhover-background-color': *SECONDARY_COLOR
 'c-bhover-background-start': *SECONDARY_COLOR
 'c-bhover-background-end': *SECONDARY_COLOR
 'c-bhover-color': '#fff'

--- a/themes/base.yaml
+++ b/themes/base.yaml
@@ -30,7 +30,7 @@
 'a-bar-background-color': *BASE_COLOR
 'b-bar-background-end': *BASE_COLOR
 'b-bar-background-start': *SECONDARY_COLOR
-'b-bar-background-color': *SECONDARY_COLOR
+'b-bar-background-color': *BASE_COLOR
 'a-bar-dropshadow-color': 'rgba(0,0,0,0.15)'
 
 # Typography
@@ -72,6 +72,7 @@
 'c-bhover-background-start': *SECONDARY_COLOR
 'c-bhover-background-end': *SECONDARY_COLOR
 'c-bhover-color': '#fff'
+'c-bdown-background-color': *BASE_COLOR
 'c-bdown-background-start': *BASE_COLOR
 'c-bdown-background-end': *BASE_COLOR
 'c-bup-shadow-x': '0px'

--- a/themes/base.yaml
+++ b/themes/base.yaml
@@ -46,8 +46,10 @@
 'global-active-border': *SECONDARY_COLOR
 
 'a-bup-border': *BASE_COLOR
+'a-bup-background-color': *SECONDARY_COLOR
 'a-bup-background-start': *SECONDARY_COLOR
 'a-bup-background-end': *SECONDARY_COLOR
+'a-bhover-background-color': *SECONDARY_COLOR
 'a-bhover-background-start': *SECONDARY_COLOR
 'a-bhover-background-end': *SECONDARY_COLOR
 'a-bhover-border': *BASE_COLOR
@@ -56,6 +58,7 @@
 'a-header-bhover-background-end': *SECONDARY_COLOR
 'a-header-bhover-border': *HIGHLIGHT_COLOR
 'a-header-bhover-color': '#fff'
+'a-bdown-background-color': *BASE_COLOR
 'a-bdown-background-start': *BASE_COLOR
 'a-bdown-background-end': *BASE_COLOR
 'a-bup-color': '#fff'

--- a/themes/base.yaml
+++ b/themes/base.yaml
@@ -27,7 +27,7 @@
 'b-bar-border': *HIGHLIGHT_COLOR
 'a-bar-background-end': *BASE_COLOR
 'a-bar-background-start': *SECONDARY_COLOR
-'a-bar-background-color': *SECONDARY_COLOR
+'a-bar-background-color': *BASE_COLOR
 'b-bar-background-end': *BASE_COLOR
 'b-bar-background-start': *SECONDARY_COLOR
 'b-bar-background-color': *SECONDARY_COLOR

--- a/themes/slate.yaml
+++ b/themes/slate.yaml
@@ -41,9 +41,11 @@ name: slate
 'global-active-border': '#484848'
 
 'a-bup-border': '#000000'
+'a-bup-background-color': '#333333'
 'a-bup-background-start': '#333333'
 'a-bup-background-end': '#333333'
 'a-bup-color': '#C4C2C2'
+'a-bhover-background-color': '#222222'
 'a-bhover-background-start': '#222222'
 'a-bhover-background-end': '#222222'
 'a-bhover-border': '#222222'
@@ -52,6 +54,7 @@ name: slate
 'a-header-bhover-background-end': '#333'
 'a-header-bhover-border': '#000'
 'a-header-bhover-color': '#fff'
+'a-bdown-background-color': '#222222'
 'a-bdown-background-start': '#222222'
 'a-bdown-background-end': '#222222'
 'a-bup-color': '#fff'
@@ -61,6 +64,7 @@ name: slate
 
 'c-bup-background-start': '#fff'
 'c-bup-background-end': '#fff'
+'c-bhover-background-color': '#333333'
 'c-bhover-background-start': '#333333'
 'c-bhover-background-end': '#333333'
 'c-bhover-color': '#fff'

--- a/themes/slate.yaml
+++ b/themes/slate.yaml
@@ -68,6 +68,7 @@ name: slate
 'c-bhover-background-start': '#333333'
 'c-bhover-background-end': '#333333'
 'c-bhover-color': '#fff'
+'c-bdown-background-color': '#333333'
 'c-bdown-background-start': '#333333'
 'c-bdown-background-end': '#333333'
 'c-bup-shadow-x': '0px'


### PR DESCRIPTION
Hey,

I believe I was able to fix the rendering in IE9. I added background color styles in the base.yaml and slate.yaml for the elements that were rendering incorrectly. IE9 does not support linear gradients so it needed a background color to fallback to. Now it seems to render correctly on my IE9, but I'm not 100%. Please review this and let me know.

If you find problems with it let me know and I'll be happy to fix and resubmit the pull request.

![graphite-fix](https://f.cloud.github.com/assets/706967/481098/fdd20a30-b849-11e2-9ad1-cef615f37b72.png)
